### PR TITLE
fix: custom authentications per resource not being picked up

### DIFF
--- a/config/parser.go
+++ b/config/parser.go
@@ -200,7 +200,7 @@ func ParseConfig() {
 			log.Fatalf(`could not parse the number of authentications to create per resource: %s`, err)
 		}
 
-		EndpointsPerSource = tmp
+		AuthenticationsPerResource = tmp
 	}
 
 	// Initialize the endpoint URLs we will be sending the requests to.


### PR DESCRIPTION
I forgot to modify the code which was copied from a block above to actually make it use a custom number of authentications.