### PR TITLE
refactor: remove "warn" level from the logger

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ to send at the same time.
 
 ### Optional values
 * `CONCURRENT_REQUESTS`. Default value: `10`.
-* `LOG_LEVEL`. One of `debug`, `info`, `warn` or `error`. Default value: `info`.
+* `LOG_LEVEL`. One of `debug`, `info` or `error`. Default value: `info`.
 * `NUMBER_OF_TENANTS`. Default value: `3`
 * `SOURCES_PER_TENANT`. Default value: `10`
 * `RHC_CONNECTIONS_PER_TENANT`. Default value: `10`

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -18,8 +18,6 @@ func InitializeLogger() {
 	switch config.LogLevel {
 	case "error":
 		atomicLogLevel = zap.NewAtomicLevelAt(zap.ErrorLevel)
-	case "warn":
-		atomicLogLevel = zap.NewAtomicLevelAt(zap.WarnLevel)
 	case "debug":
 		atomicLogLevel = zap.NewAtomicLevelAt(zap.DebugLevel)
 	case "info":


### PR DESCRIPTION
We don't use the "warn" level with the Zap logger. The only place we issue warnings is when parsing invalid environment variables, and there we use the standard logger because Zap hasn't yet been initialized.