### PR TITLE
fix docs: the note should not be part of the env vars table

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,4 +27,5 @@ to send at the same time.
 | `APPLICATIONS_PER_SOURCE`      | 10            |
 | `ENDPOINTS_PER_SOURCE`         | 10            |
 | `AUTHENTICATIONS_PER_RESOURCE` | 3             |
+
 _**Note**: the log level can be one of "debug", "info" or "error"._


### PR DESCRIPTION
GitHub's Markdown implementation puts the note inside the table if the note isn't separated with a new line from the table.