### PR TITLE
chore: remove the generated default binary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Generated default binary
+sources-database-populator
+
 # IDE
 .idea/
 


### PR DESCRIPTION
I forgot not to include it in a previous commit. I added a ".gitignore" ignore too to avoid making the same mistake in the future.