### PR TITLE
fix: database populator doesn't create applications properly

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,6 @@ to send at the same time.
 | `NUMBER_OF_TENANTS`            | 3             |
 | `SOURCES_PER_TENANT`           | 10            |
 | `RHC_CONNECTIONS_PER_TENANT`   | 10            |
-| `APPLICATIONS_PER_SOURCE`      | 10            |
 | `ENDPOINTS_PER_SOURCE`         | 10            |
 | `AUTHENTICATIONS_PER_RESOURCE` | 3             |
 

--- a/config/parser.go
+++ b/config/parser.go
@@ -36,9 +36,6 @@ const defaultTenants = 3
 // sourcesV31Path is the path to the latest API version.
 const sourcesV31Path = "api/sources/v3.1"
 
-// ApplicationsPerSource is the number of applications the program will create for each source_types_db.
-var ApplicationsPerSource int
-
 // AuthenticationsPerResource is the number of authentications the program will create for each resource.
 var AuthenticationsPerResource int
 
@@ -187,19 +184,6 @@ func ParseConfig() {
 		}
 
 		RhcConnectionsPerTenant = tmp
-	}
-
-	// Get the applications to create per source_types_db.
-	applicationsPerSource := os.Getenv("APPLICATIONS_PER_SOURCE")
-	if applicationsPerSource == "" {
-		ApplicationsPerSource = defaultApplicationsPerSource
-	} else {
-		tmp, err := strconv.Atoi(applicationsPerSource)
-		if err != nil {
-			log.Fatalf(`could not parse the number of applications to create per source_types_db: %s`, err)
-		}
-
-		ApplicationsPerSource = tmp
 	}
 
 	// Get the endpoints to create per source_types_db.

--- a/source_types_db/source_types_db.go
+++ b/source_types_db/source_types_db.go
@@ -127,8 +127,8 @@ func (sdb SourceTypesDb) GetRandomAuthenticationTypeForSource(sourceTypeId strin
 	return st.CompatibleAuthentications[idx]
 }
 
-// GetRandomApplicationType gets a random application type that is compatible with the provided source type id.
-func (sdb SourceTypesDb) GetRandomApplicationType(sourceTypeId string) ApplicationType {
+// GetApplicationTypes returns the list of the compatible application types for the given source.
+func (sdb SourceTypesDb) GetApplicationTypes(sourceTypeId string) []ApplicationType {
 	st := sourceTypes[sourceTypeId]
 
 	var applicationTypes = make([]ApplicationType, 0, len(st.CompatibleApplicationTypes))
@@ -136,11 +136,7 @@ func (sdb SourceTypesDb) GetRandomApplicationType(sourceTypeId string) Applicati
 		applicationTypes = append(applicationTypes, appType)
 	}
 
-	// Get a random index for the array.
-	randomIdx := rand.Intn(len(applicationTypes))
-
-	// Get a random application type.
-	return applicationTypes[randomIdx]
+	return applicationTypes
 }
 
 // GetRandomSourceType returns a random source type from the database.


### PR DESCRIPTION
Due to the latest changes on the sources API's back end, the database
populator was erroring time and again. The main change on the sources
API has been that now sources can only have one compatible application
per application type, and therefore when the populator was trying to
POST applications which an application type that already existed on the
database, the back end complained.